### PR TITLE
Add suggest eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "blimp"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "mkdir -p dist && browserify --standalone coreapi -d -t babelify lib/index.js -o dist/coreapi.js",
     "watch": "watchify --standalone coreapi -t babelify lib/index.js -o dist/coreapi.js -v",
     "prepublish": "npm run build",
-    "test": "node tests/basic.js"
+    "test": "node tests/basic.js",
+    "test:lint": "eslint lib"
   },
   "repository": {
     "type": "git",
@@ -27,9 +28,13 @@
     "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
+    "babel-eslint": "^6.1.2",
     "babel-preset-es2015": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
+    "eslint": "^3.9.1",
+    "eslint-config-blimp": "^3.5.1",
+    "eslint-plugin-babel": "^3.3.0",
     "expect": "^1.20.2",
     "watchify": "^3.7.0"
   }


### PR DESCRIPTION
ESLint is a pretty great linter for JavaScript. I've set it up using [eslint-config-blimp](https://github.com/GetBlimp/eslint-config-blimp) which we use for all of our projects. Open to suggestions of extending from another one, if desired.

```
$ npm run test:lint

> coreapi@0.0.3 test:lint /Users/jpadilla/Projects/Personal/coreapi/javascript-client
> eslint lib


/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/client.js
  14:45  error  Unexpected trailing comma  comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/codecs/corejson.js
  10:42  error  Unexpected trailing comma  comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/codecs/index.js
  6:5   error  Expected indentation of 2 spaces but found 4  indent
  7:5   error  Expected indentation of 2 spaces but found 4  indent
  8:5   error  Expected indentation of 2 spaces but found 4  indent
  8:25  error  Unexpected trailing comma                     comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/codecs/json.js
  8:34  error  Unexpected trailing comma  comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/codecs/text.js
  8:24  error  Unexpected trailing comma  comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/index.js
  6:21  error  Unexpected trailing comma  comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/transports/http.js
   8:7   error  Expected space(s) after "if"  keyword-spacing
  23:31  error  Unexpected trailing comma     comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/transports/index.js
  4:31  error  Unexpected trailing comma  comma-dangle

/Users/jpadilla/Projects/Personal/coreapi/javascript-client/lib/utils.js
   1:49  error  'url' is defined but never used                     no-unused-vars
   6:23  error  Unexpected use of undefined                         no-undefined
  15:12  error  'decoder' is never reassigned. Use 'const' instead  prefer-const
  26:37  error  Unexpected trailing comma                           comma-dangle
  27:2   error  Missing semicolon                                   semi

✖ 17 problems (17 errors, 0 warnings)
```