### PR TITLE
Fix null contentType in negotiateDecoder

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ const determineTransport = function (transports, url) {
 }
 
 const negotiateDecoder = function (decoders, contentType) {
-  if (contentType === undefined) {
+  if (contentType === undefined || contentType === null) {
     return decoders[0]
   }
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -29,6 +29,12 @@ describe('Test the Utils/negotiateDecoder function', function () {
     expect(result instanceof coreapi.codecs.CoreJSONCodec).toBeTruthy()
   })
 
+  it('should return the default decoder if content type is null', function () {
+    const contentType = null
+    const result = utils.negotiateDecoder(decoders, contentType)
+    expect(result instanceof coreapi.codecs.CoreJSONCodec).toBeTruthy()
+  })
+
   it('should return the decoder for a content type (application/json)', function () {
     const contentType = 'application/json'
     const result = utils.negotiateDecoder(decoders, contentType)


### PR DESCRIPTION
If the content type is null the default decoder is not returned, giving ` TypeError: Cannot read property 'toLowerCase' of null `.