### PR TITLE
support multipart/form-data (e.g. file uploads)

### DIFF
--- a/lib/codecs/corejson.js
+++ b/lib/codecs/corejson.js
@@ -73,6 +73,7 @@ function primitiveToNode (data, baseUrl) {
     const title = getString(data, 'title')
     const description = getString(data, 'description')
     const fieldsData = getArray(data, 'fields')
+    const encoding = getString(data, 'encoding') || 'application/json'
     var fields = []
     for (let idx = 0, len = fieldsData.length; idx < len; idx++) {
       let value = fieldsData[idx]
@@ -83,7 +84,7 @@ function primitiveToNode (data, baseUrl) {
       let field = new document.Field(name, required, location, fieldDescription)
       fields.push(field)
     }
-    return new document.Link(url, method, 'application/json', fields, title, description)
+    return new document.Link(url, method, encoding, fields, title, description)
   } else if (isObject) {
     // Object
     let content = {}

--- a/tests/codecs/corejson.js
+++ b/tests/codecs/corejson.js
@@ -81,6 +81,22 @@ describe('Test the CoreJSON Codec', function () {
     expect(node.fields).toEqual([new document.Field('foo', true)])
   })
 
+  it('should test decoding a link without declared encoding', function () {
+    const text = '{"_type": "link", "url": "http://example.com/", "fields": [{"name": "foo", "required": true}]}'
+    const node = codec.decode(text)
+    expect(node instanceof document.Link).toBeTruthy()
+    expect(node.fields).toEqual([new document.Field('foo', true)])
+    expect(node.encoding).toEqual('application/json')
+  })
+
+  it('should test decoding a link with declared encoding', function () {
+    const text = '{"_type": "link", "url": "http://example.com/", "encoding": "multipart/form-data", "fields": [{"name": "foo", "required": true}]}'
+    const node = codec.decode(text)
+    expect(node instanceof document.Link).toBeTruthy()
+    expect(node.fields).toEqual([new document.Field('foo', true)])
+    expect(node.encoding).toEqual('multipart/form-data')
+  })
+
   it('should test decoding a primitive', function () {
     const text = '123'
     const node = codec.decode(text)


### PR DESCRIPTION
This patch enables file uploads by allowing multipart/form-data encoding in transport.

# Usage example

(this took me a while to figure out, feel free to add this to the docs)

## Server (Django)

```python
from rest_framework import serializers, viewsets, parsers

# serializer with file field
class AttachmentSerializer(serializers.Serializer):
    file = serializers.FileField(write_only=True)

# viewset with upload method
class MyViewset(viewsets.ModelViewSet):
  # ...
  @detail_route(methods=['post'],
                serializer_class=AttachmentSerializer, 
                parser_classes=(parsers.MultiPartParser,))
  def add_attachment(self, request, *args, **kwargs):
      serializer = serializers.AttachmentSerializer(data=request.data)
      if serializer.is_valid():
          # serializer.validated_data['file'] is an instance of django.core.files.File
          print("uploaded file: %s" %  serializer.validated_data['file']
```
## Client (JS)

```javascript
const client = new coreapi.Client()
const schema = window.schema

// file must be either an instance of Blob (for content generated in JS) or 
// an instance of File (retrieved from an <input type="file"> or a dropEvent.FileList)

client.action(schema,
              ['mymodel', 'add_attachment'],
              {id: id, file: file})
      .then((result) => console.log(result))
```
