### PR TITLE
Improved HTTP transport handling of query parameters

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -104,8 +104,8 @@ class HTTPTransport {
 
     let parsedUrl = urlTemplate.parse(link.url)
     parsedUrl = parsedUrl.expand(pathParams)
-    parsedUrl = new URL(parsedUrl)
-    parsedUrl.set('query', queryParams)
+    parsedUrl = new URL(parsedUrl, null, true)
+    parsedUrl.set('query', Object.assign(parsedUrl.query, queryParams))
 
     return {
       url: parsedUrl.toString(),

--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -107,8 +107,36 @@ class HTTPTransport {
     parsedUrl = new URL(parsedUrl)
     parsedUrl.set('query', queryParams)
 
+    // Modified querystringify to parse lists into repeated querystring keys
+    function querystringify (obj, prefix) {
+      var has = Object.prototype.hasOwnProperty
+      prefix = prefix || ''
+
+      var pairs = []
+
+      //
+      // Optionally prefix with a '?' if needed
+      //
+      if (typeof prefix !== 'string') prefix = '?'
+
+      for (var key in obj) {
+        if (has.call(obj, key)) {
+          let value = obj[key]
+          if (Array.isArray(value)) {
+            for (let item of value) {
+              pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(item))
+            }
+          } else {
+            pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(value))
+          }
+        }
+      }
+
+      return pairs.length ? prefix + pairs.join('&') : ''
+    }
+
     return {
-      url: parsedUrl.toString(),
+      url: parsedUrl.toString(querystringify),
       options: requestOptions
     }
   }

--- a/tests/transports/http.js
+++ b/tests/transports/http.js
@@ -108,6 +108,25 @@ describe('Test the HTTPTransport', function () {
       })
   })
 
+  it('should check the action function of an HTTP transport (json) with query params and existing querystring in url', function () {
+    const url = 'http://www.example.com/?next=2'
+    const fields = [new document.Field('page', false, 'query')]
+    const link = new document.Link(url, 'get', 'application/json', fields)
+    const transport = new transports.HTTPTransport({
+      fetch: testUtils.echo
+    })
+    const params = {
+      page: 23
+    }
+
+    return transport.action(link, decoders, params)
+      .then((res) => {
+        expect(res.url).toMatch(/http:\/\/www.example.com\/\?(page=23&(?=next=2)|next=2&(?=page=23))/)
+        expect(res).toHaveProperty('headers', {})
+        expect(res).toHaveProperty('method', 'GET')
+      })
+  })
+
   it('should check the action function of an HTTP transport (json) with path params', function () {
     const url = 'http://www.example.com/{user}/'
     const fields = [new document.Field('user', true, 'path')]
@@ -241,6 +260,21 @@ describe('Test the HTTPTransport', function () {
     return transport.action(link, decoders, params)
       .then((res) => {
         expect(res).toEqual({url: 'http://www.example.com/', headers: {}, method: 'GET'})
+      })
+  })
+
+  it('should check the action function of an HTTP transport (json) with querystring in url and missing optional query params', function () {
+    const url = 'http://www.example.com/?next=1'
+    const fields = [new document.Field('page', false, 'query')]
+    const link = new document.Link(url, 'get', 'application/json', fields)
+    const transport = new transports.HTTPTransport({
+      fetch: testUtils.echo
+    })
+    const params = {}
+
+    return transport.action(link, decoders, params)
+      .then((res) => {
+        expect(res).toEqual({url: 'http://www.example.com/?next=1', headers: {}, method: 'GET'})
       })
   })
 

--- a/tests/transports/http.js
+++ b/tests/transports/http.js
@@ -108,6 +108,23 @@ describe('Test the HTTPTransport', function () {
       })
   })
 
+  it('should check the action function of an HTTP transport (json) with list-type query params', function () {
+    const url = 'http://www.example.com/'
+    const fields = [new document.Field('pages', false, 'query')]
+    const link = new document.Link(url, 'get', 'application/json', fields)
+    const transport = new transports.HTTPTransport({
+      fetch: testUtils.echo
+    })
+    const params = {
+      pages: [22, 23]
+    }
+
+    return transport.action(link, decoders, params)
+      .then((res) => {
+        expect(res).toEqual({url: 'http://www.example.com/?pages=22&pages=23', headers: {}, method: 'GET'})
+      })
+  })
+
   it('should check the action function of an HTTP transport (json) with path params', function () {
     const url = 'http://www.example.com/{user}/'
     const fields = [new document.Field('user', true, 'path')]


### PR DESCRIPTION
I am using coreapi to interact with an api that provides links in responses, that at times I would like to follow using the Client.get() method. These links include query parameters at times. A common example is listing paginated entries, wherein the page number for the "next" page may be a query parameter.

This pull request includes a minor change to the URL parser that allows it to combine query parameters that already exist in the url with those specified separately. This behavior is consistent with the python client.

I also included two tests: one with and one without query parameters specified outside the URL.