### PR TITLE
Query parameters of type Array stringified to repeated key,value pairs

### DIFF
--- a/lib/transports/http.js
+++ b/lib/transports/http.js
@@ -107,8 +107,36 @@ class HTTPTransport {
     parsedUrl = new URL(parsedUrl)
     parsedUrl.set('query', queryParams)
 
+    // Modified querystringify to parse lists into repeated querystring keys
+    function querystringify (obj, prefix) {
+      var has = Object.prototype.hasOwnProperty
+      prefix = prefix || ''
+
+      var pairs = []
+
+      //
+      // Optionally prefix with a '?' if needed
+      //
+      if (typeof prefix !== 'string') prefix = '?'
+
+      for (var key in obj) {
+        if (has.call(obj, key)) {
+          let value = obj[key]
+          if (Array.isArray(value)) {
+            for (let item of value) {
+              pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(item))
+            }
+          } else {
+            pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(value))
+          }
+        }
+      }
+
+      return pairs.length ? prefix + pairs.join('&') : ''
+    }
+
     return {
-      url: parsedUrl.toString(),
+      url: parsedUrl.toString(querystringify),
       options: requestOptions
     }
   }

--- a/tests/transports/http.js
+++ b/tests/transports/http.js
@@ -108,6 +108,23 @@ describe('Test the HTTPTransport', function () {
       })
   })
 
+  it('should check the action function of an HTTP transport (json) with list-type query params', function () {
+    const url = 'http://www.example.com/'
+    const fields = [new document.Field('pages', false, 'query')]
+    const link = new document.Link(url, 'get', 'application/json', fields)
+    const transport = new transports.HTTPTransport({
+      fetch: testUtils.echo
+    })
+    const params = {
+      pages: [22, 23]
+    }
+
+    return transport.action(link, decoders, params)
+      .then((res) => {
+        expect(res).toEqual({url: 'http://www.example.com/?pages=22&pages=23', headers: {}, method: 'GET'})
+      })
+  })
+
   it('should check the action function of an HTTP transport (json) with path params', function () {
     const url = 'http://www.example.com/{user}/'
     const fields = [new document.Field('user', true, 'path')]


### PR DESCRIPTION
This pull request implements issue #36 by supplying a custom querystringify function to the URL parser. The function passed is based on the default but checks for array types and splits them.