### PR TITLE
Link's encoding is no longer fixed to `application/json`, it's from the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ To run the tests (linting & unit tests):
 [npm-url]: http://badge.fury.io/js/coreapi
 [codecov-image]: https://codecov.io/gh/core-api/javascript-client/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/core-api/javascript-client
+
+
+# Fixed
+
+Link's encoding is no longer fixed to `application/json`, it's from the schema.

--- a/lib/codecs/corejson.js
+++ b/lib/codecs/corejson.js
@@ -73,6 +73,7 @@ function primitiveToNode (data, baseUrl) {
     const title = getString(data, 'title')
     const description = getString(data, 'description')
     const fieldsData = getArray(data, 'fields')
+    const encoding = getString(data, 'encoding') || 'application/json'
     var fields = []
     for (let idx = 0, len = fieldsData.length; idx < len; idx++) {
       let value = fieldsData[idx]
@@ -83,7 +84,7 @@ function primitiveToNode (data, baseUrl) {
       let field = new document.Field(name, required, location, fieldDescription)
       fields.push(field)
     }
-    return new document.Link(url, method, 'application/json', fields, title, description)
+    return new document.Link(url, method, encoding, fields, title, description)
   } else if (isObject) {
     // Object
     let content = {}


### PR DESCRIPTION
when dealing with drf's FileField use this client, get a content-type error.Then I find the Link's is fixed to 'application/json', which is not right, then I fix it.